### PR TITLE
Add Clear button to Activity card

### DIFF
--- a/ipcHandlers.js
+++ b/ipcHandlers.js
@@ -392,7 +392,8 @@ const ActivityManager = {
       (typeof item.id === 'string' || item.id === null) && // Allow null id (will be generated)
       typeof item.title === 'string' &&
       typeof item.subtitle === 'string' &&
-      (typeof item.timestamp === 'number' || typeof item.timestamp === 'undefined') && // Allow missing timestamp
+      (typeof item.timestamp === 'number' ||
+        typeof item.timestamp === 'undefined') && // Allow missing timestamp
       (item.timestamp === undefined || item.timestamp > 0)
     );
   },

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -371,6 +371,20 @@
       });
     }, []);
 
+    // ==================== ACTIVITY FUNCTIONS ====================
+
+    /**
+     * Clears all activity items from both UI and persistent storage
+     */
+    async function clearActivity() {
+      try {
+        await window.roon.clearActivity();
+        console.log('[UI] Cleared persistent activity');
+      } catch (error) {
+        console.error('Failed to clear persistent activity:', error);
+      }
+    }
+
     // Return public API
     return {
       // State
@@ -389,6 +403,7 @@
       playRandomAlbumByArtist,
       transportControl,
       changeVolume,
+      clearActivity, // NEW
     };
   }
 
@@ -1250,12 +1265,49 @@
       setSubgenresCache,
     });
 
+    // ==================== ACTIVITY HELPER FUNCTIONS ====================
+
+    /**
+     * Handles clearing the activity list
+     */
+    async function handleClearActivity() {
+      try {
+        await roon.clearActivity();
+        setActivity([]);
+        console.log('[UI] Activity cleared');
+      } catch (error) {
+        console.error('Failed to clear activity:', error);
+      }
+    }
+
     // ==================== RENDER ACTIVITY CARD ====================
 
     const activityCard = e(
       'div',
       { className: 'card activity-card' },
-      e('h2', null, 'Activity'),
+      // Header with clear button
+      e(
+        'div',
+        {
+          style: {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexShrink: 0,
+          },
+        },
+        e('h2', { style: { margin: 0, marginBottom: 10 } }, 'Activity'),
+        e(
+          'button',
+          {
+            className: 'btn-link',
+            onClick: handleClearActivity,
+            disabled: activity.length === 0,
+            style: { transform: 'translateY(-4px)' },
+          },
+          'Clear'
+        )
+      ),
       e(
         'div',
         { className: 'activity' },


### PR DESCRIPTION
## Summary
- Add Clear button to Activity card header matching the Reload Genres button style
- Button is disabled when activity list is empty for better UX
- Clears both persistent storage (backend) and UI state when clicked
- Uses existing clearActivity IPC handler that was already implemented

## Test plan
- [x] Verify Clear button appears in Activity card header
- [x] Verify button is disabled when activity list is empty
- [x] Verify clicking Clear removes all activity items from UI
- [x] Verify activity items don't reappear after app restart (persistent storage cleared)
- [x] Verify button styling matches the existing Reload Genres button

🤖 Generated with [Claude Code](https://claude.ai/code)