### PR TITLE
UI polish: transport hover, progress handle, timestamps, labels, image fix

### DIFF
--- a/ipcHandlers.js
+++ b/ipcHandlers.js
@@ -68,7 +68,6 @@ const RATE_LIMITS_MS = {
   PLAY_RANDOM_ALBUM: 500,
   PLAY_ALBUM_BY_NAME: 500,
   PLAY_RANDOM_ALBUM_BY_ARTIST: 500,
-  GET_IMAGE: 100,
 };
 
 function createRateLimitedHandler(channel, intervalMs, handler) {
@@ -548,33 +547,26 @@ function registerMediaHandlers(store) {
    * @param {Object} options - Image options (scale, width, height, format)
    * @returns {Promise<string|null>} Data URL or null if not found
    */
-  ipcMain.handle(
-    IPC_CHANNELS.GET_IMAGE,
-    createRateLimitedHandler(
-      IPC_CHANNELS.GET_IMAGE,
-      RATE_LIMITS_MS.GET_IMAGE,
-      async (_event, imageKey, options) => {
-        // Validate image key
-        if (!Validators.isNonEmptyString(imageKey, 500)) {
-          console.error('Invalid image key: must be a non-empty string');
-          return null;
-        }
+  ipcMain.handle(IPC_CHANNELS.GET_IMAGE, async (_event, imageKey, options) => {
+    // Validate image key
+    if (!Validators.isNonEmptyString(imageKey, 500)) {
+      console.error('Invalid image key: must be a non-empty string');
+      return null;
+    }
 
-        // Validate options if provided
-        if (options !== undefined && !Validators.isObject(options)) {
-          console.error('Invalid image options: must be an object');
-          return null;
-        }
+    // Validate options if provided
+    if (options !== undefined && !Validators.isObject(options)) {
+      console.error('Invalid image options: must be an object');
+      return null;
+    }
 
-        try {
-          return await RoonService.getImageDataUrl(imageKey, options);
-        } catch (error) {
-          console.error('Failed to get image:', error);
-          return null;
-        }
-      }
-    )
-  );
+    try {
+      return await RoonService.getImageDataUrl(imageKey, options);
+    } catch (error) {
+      console.error('Failed to get image:', error);
+      return null;
+    }
+  });
 
   /**
    * Sends transport control commands (play, pause, next, previous)

--- a/renderer/components/GenreFilter.js
+++ b/renderer/components/GenreFilter.js
@@ -136,7 +136,11 @@ export function GenreFilter(props) {
           flexShrink: 0,
         },
       },
-      e('h2', { style: { margin: 0, marginBottom: 10 } }, 'Filter by Genre'),
+      e(
+        'h2',
+        { style: { margin: 0, marginBottom: 10 } },
+        'Filter Albums by Genre'
+      ),
       e(
         'button',
         {

--- a/renderer/components/SettingsModal.js
+++ b/renderer/components/SettingsModal.js
@@ -39,17 +39,12 @@ export function SettingsModal(props) {
         className: 'modal-content',
         onClick: evt => evt.stopPropagation(), // Prevent closing when clicking inside
       },
-      e('h2', null, 'Settings'),
+      e('h2', null, 'Filter by Artist'),
 
       // Artist Exclusions Section
       e(
         'div',
         { style: { marginTop: '24px' } },
-        e(
-          'h3',
-          { style: { fontSize: '16px', marginBottom: '12px' } },
-          'Excluded Artists'
-        ),
         e(
           'p',
           {
@@ -92,6 +87,12 @@ export function SettingsModal(props) {
               'Add'
             )
           )
+        ),
+
+        e(
+          'h3',
+          { style: { fontSize: '16px', marginBottom: '12px' } },
+          'Excluded Artists'
         ),
 
         // Clear All button

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -285,6 +285,7 @@
         border-radius: 2px;
       }
 
+
       /* Progress bar styling */
       .progress-container {
         display: flex;
@@ -306,7 +307,6 @@
         height: 4px;
         background: var(--border);
         border-radius: 2px;
-        overflow: hidden;
         position: relative;
       }
 
@@ -316,6 +316,24 @@
         width: 0%;
         transition: width 0.1s linear;
         border-radius: 2px;
+        position: relative;
+      }
+
+      .progress-fill::after {
+        content: '';
+        position: absolute;
+        right: -5px;
+        top: 50%;
+        transform: translateY(-50%) scale(0);
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #6b7280;
+        transition: transform 0.15s ease;
+      }
+
+      .progress-bar:hover .progress-fill::after {
+        transform: translateY(-50%) scale(1);
       }
 
       /* Volume slider - Webkit only styling for Electron */
@@ -457,16 +475,17 @@
         appearance: none;
         background: none;
         border: none;
-        padding: 0;
+        padding: 6px;
+        border-radius: 50%;
         cursor: pointer;
         line-height: 0;
+        transition: background-color 0.15s ease;
       }
 
       .btn-icon img {
         width: 36px;
         height: 36px;
         object-fit: contain;
-        transition: opacity 0.15s ease-in-out;
       }
 
       .btn-playpause img {
@@ -474,8 +493,14 @@
         height: 52px;
       }
 
-      .btn-icon:hover img {
-        opacity: 0.5;
+      .btn-icon:hover {
+        background-color: rgba(0, 0, 0, 0.06);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .btn-icon:hover {
+          background-color: rgba(255, 255, 255, 0.1);
+        }
       }
 
       .btn-icon:disabled {

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -539,6 +539,13 @@ function App() {
   // Settings modal state (for artist exclusions)
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
 
+  // Tick state to force relative timestamp re-renders every 60 seconds
+  const [, setTimestampTick] = useState(0);
+  useEffect(() => {
+    const interval = setInterval(() => setTimestampTick(n => n + 1), 60 * 1000);
+    return () => clearInterval(interval);
+  }, []);
+
   // Load connection settings on mount
   useEffect(() => {
     async function loadConnectionSettings() {
@@ -636,34 +643,34 @@ function App() {
         );
 
         // Convert persisted activity to UI format (with album art)
-        const activityWithArt = await Promise.all(
-          (persistedActivity || [])
-            .slice(0, ACTIVITY_HISTORY_LIMIT)
-            .map(async item => {
-              let artUrl = null;
+        // Fetch images sequentially to avoid hitting the rate limiter
+        const activityWithArt = [];
+        for (const item of (persistedActivity || []).slice(
+          0,
+          ACTIVITY_HISTORY_LIMIT
+        )) {
+          let artUrl = null;
 
-              // Fetch album art if we have an image key
-              if (item.imageKey) {
-                try {
-                  artUrl = await window.roon.getImage(item.imageKey);
-                } catch (error) {
-                  console.warn(
-                    `Failed to load album art for ${item.title}:`,
-                    error
-                  );
-                }
-              }
+          if (item.imageKey) {
+            try {
+              artUrl = await window.roon.getImage(item.imageKey);
+            } catch (error) {
+              console.warn(
+                `Failed to load album art for ${item.title}:`,
+                error
+              );
+            }
+          }
 
-              return {
-                id: item.id, // Preserve ID for removal
-                title: item.title,
-                subtitle: item.subtitle,
-                art: artUrl,
-                t: item.timestamp,
-                key: item.key || createActivityKey(item.title, item.subtitle),
-              };
-            })
-        );
+          activityWithArt.push({
+            id: item.id,
+            title: item.title,
+            subtitle: item.subtitle,
+            art: artUrl,
+            t: item.timestamp,
+            key: item.key || createActivityKey(item.title, item.subtitle),
+          });
+        }
 
         setActivity(activityWithArt);
       } catch (error) {


### PR DESCRIPTION
## Summary

- **Transport buttons**: hover now shows a subtle circular background instead of opacity-dim (which read as disabled)
- **Progress bar**: scrub handle appears on hover via `::after` pseudo-element; removed `overflow:hidden` that was clipping it
- **Activity feed images**: fetch sequentially on startup instead of all at once via `Promise.all`, which was hitting the rate limiter and leaving all but the first image blank; also removed the `getImage` IPC rate limit entirely since the Roon image service has its own cache
- **Genre card**: header renamed to "Filter Albums by Genre" — clarifies what the counts in parentheses mean
- **Settings modal**: renamed to "Filter by Artist"; "Excluded Artists" heading moved below the input so the form has clear context before the list
- **Timestamps**: 60-second interval tick keeps relative times ("just now", "5m ago") accurate during long sessions

## Test plan

- [ ] Transport button hover shows circular background, not opacity dim
- [ ] Progress bar shows scrub handle on hover
- [ ] Activity feed images all load on startup (no rate limit errors in console)
- [ ] Genre card header reads "Filter Albums by Genre"
- [ ] Filter icon opens panel titled "Filter by Artist" with input above "Excluded Artists" list
- [ ] Relative timestamps update correctly after 60+ seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)